### PR TITLE
Fix port range error message typo

### DIFF
--- a/frontend-windows-client/BatRadio.UI/frmMain.cs
+++ b/frontend-windows-client/BatRadio.UI/frmMain.cs
@@ -174,7 +174,7 @@ namespace BatRadio.UI
 
             if (port < 1024 || port > 65535)
             {
-                throw new Exception("A porta do sevidor deve estar entre 1024 e 65535");
+                throw new Exception("A porta do servidor deve estar entre 1024 e 65535");
             }
             BatRadioClient.RadioConfig.Server = textboxServerAddress.Text;
             BatRadioClient.RadioConfig.Port = port;


### PR DESCRIPTION
## Summary
- fix typo in error message for server port range in frmMain.cs

## Testing
- `grep -n "A porta do servidor" -n frontend-windows-client/BatRadio.UI/frmMain.cs`


------
https://chatgpt.com/codex/tasks/task_e_684898a3c0f4832c963aa18815877918